### PR TITLE
Uses ssh_config values, if defined, as defaults

### DIFF
--- a/next_review.py
+++ b/next_review.py
@@ -305,9 +305,19 @@ def main(args):
 
     sys.exit(len(reviews))
 
+def merge_ssh_config(args):
+    ssh_config = paramiko.SSHConfig()
+    ssh_config.parse(open(os.path.expanduser('~/.ssh/config')))
+    host_config = ssh_config.lookup(args.host)
+
+    if 'user' in host_config and not args.username:
+        args.username = host_config['user']
+    if 'identityfile' in host_config and not args.key:
+        args.key = host_config['identityfile']
 
 def cli():
     args = get_config()
+    merge_ssh_config(args)
 
     if args.version:
         print(pkg_resources.require('next-review')[0])


### PR DESCRIPTION
This allows users to take advantage of their existing ssh_config instead
of having to use command-line arguments.